### PR TITLE
Restore and add additional parameter en-/decoding

### DIFF
--- a/AFOAuth1Client/AFOAuth1Utils.m
+++ b/AFOAuth1Client/AFOAuth1Utils.m
@@ -130,12 +130,12 @@ NSDictionary * AFOAuth1ParametersFromQueryString(NSString *queryString) {
     for (NSArray *queryItem in sortedQueryItems) {
         switch (queryItem.count) {
             case 1: {
-                NSString *key = queryItem[0];
+                NSString *key = [queryItem[0] stringByRemovingPercentEncoding];
                 parameters[key] = [NSNull null];
             } break;
             case 2: {
-                NSString *key = queryItem[0];
-                NSString *value = queryItem[1];
+                NSString *key = [queryItem[0] stringByRemovingPercentEncoding];
+                NSString *value = [queryItem[1] stringByRemovingPercentEncoding];
                 parameters[key] = value;
             } break;
             default: {

--- a/AFOAuth1Client/AFOAuth1Utils.m
+++ b/AFOAuth1Client/AFOAuth1Utils.m
@@ -93,7 +93,7 @@ NSString * AFOAuth1PlainTextSignature(NSURLRequest *request, NSString *consumerS
 
 NSString * AFOAuth1HMACSHA1Signature(NSURLRequest *request, NSString *consumerSecret, NSString *tokenSecret, NSStringEncoding stringEncoding) {
     NSString *secret = tokenSecret ? tokenSecret : @"";
-    NSString *secretString = [NSString stringWithFormat:@"%@&%@", consumerSecret ?: @"", secret ?: @""];
+    NSString *secretString = [NSString stringWithFormat:@"%@&%@", AFOAuth1PercentEscapedStringFromString(consumerSecret), AFOAuth1PercentEscapedStringFromString(secret)];
     NSData *secretStringData = [secretString dataUsingEncoding:stringEncoding];
     
     NSString *queryString = AFOAuth1PercentEscapedStringFromString(AFOAuth1SortedQueryString(request.URL.query));


### PR DESCRIPTION
**Add the percent encoding back again when creating HMAC-SHA1 signatures and newly remove the percent encodings when we receive a response from the server in the form of an query string.**

According to the [OAuth 1.0a specification](https://oauth.net/core/1.0a/) all parameters need to be percent encoded:

[5.1.  Parameter Encoding](https://oauth.net/core/1.0a/#encoding_parameters)
All parameter names and values are escaped using the [RFC3986] percent-encoding (%xx) mechanism. Characters not in the unreserved character set ([RFC3986] section 2.3) MUST be encoded. Characters in the unreserved character set MUST NOT be encoded. Hexadecimal characters in encodings MUST be upper case. Text names and values MUST be encoded as UTF-8 octets before percent-encoding them per [RFC3629].

            unreserved = ALPHA, DIGIT, '-', '.', '_', '~'

specifically in the section about creating the HMAC-SHA1:

[9.2.  HMAC-SHA1](https://oauth.net/core/1.0a/#anchor15)
The HMAC-SHA1 signature method uses the HMAC-SHA1 signature algorithm as defined in [RFC2104] where the Signature Base String is the text and the key is the concatenated values (each first encoded per Parameter Encoding) of the Consumer Secret and Token Secret, separated by an '&' character (ASCII code 38) even if empty.

and in the section about response parameters:

[5.3.  Service Provider Response Parameters](https://oauth.net/core/1.0a/#response_parameters)
Response parameters are sent by the Service Provider to return Tokens and other information to the Consumer in the HTTP response body. The parameter names and values are first encoded as per Parameter Encoding, and concatenated with the '&' character (ASCII code 38) as defined in [RFC3986] Section 2.1. For example:

            oauth_token=ab3cd9j4ks73hf7g&oauth_token_secret=xyz4992k83j47x0b