### PR TITLE
Use only the NSURLSession subspec from AFNetworking

### DIFF
--- a/AFOAuth1Client.podspec
+++ b/AFOAuth1Client.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.9'
   s.osx.frameworks = 'CoreServices', 'SystemConfiguration', 'Security'
 
-  s.dependency 'AFNetworking', '~> 3.0'
+  s.dependency 'AFNetworking/NSURLSession', '~> 3.0'
 
   s.prefix_header_contents = <<-EOS
 #import <Availability.h>


### PR DESCRIPTION
This Pod only needs the NSURLSession subspec from AFNetworking, so we can limit the dependeny to that. By depending on `AFNetworking/NSURLSession` we implicitly depend on the following subspecs:
- `AFNetworking/Serialization`
- `AFNetworking/Reachability`
- `AFNetworking/Security`

but without:
- `AFNetworking/UIKit`

By changing that we're getting one step closer to getting rid of the UIWebView references in our code base.

refs https://github.com/hausgold/hausgold-ios/issues/1302